### PR TITLE
Refactor app startup structure

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,8 +1,10 @@
-from application import application
+from application.run_server import application
 import os
 
 if __name__ == "__main__":
   if os.environ.get('IS_PRODUCTION'):
+    print('running IS_PRODUCTION')
     application.run(use_reloader=False)
   else:
+    print('running IS_DEBUG_MODE')
     application.run(debug=True, use_reloader=False)

--- a/application/__init__.py
+++ b/application/__init__.py
@@ -1,47 +1,4 @@
-from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-import os
-from flask_bcrypt import Bcrypt
-from flask_login import LoginManager
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
-
-application = Flask(__name__) # aws eb requires 'application' name for Flask instance
-application.config['SECRET_KEY'] = '7a273729d601733097ead8f655a410eb'
-
-application.config['SLACK_CLIENT_ID'] = os.environ.get('SLACK_CLIENT_ID') # stored in EB config
-application.config['SLACK_CLIENT_SECRET'] = os.environ.get('SLACK_CLIENT_SECRET') # stored in EB config
-
-PG_URL = os.environ.get('AWS_RDS_URL')
-if PG_URL != None:
-  print('USING VARIABLE %s' % PG_URL)
-  application.config['SQLALCHEMY_DATABASE_URI'] = PG_URL
-  # to set AWS database URL for EB environment: `eb use _environment-name_` (e.g. doxa-staging) then `eb set-env _database-url_`
-  # e.g. eb setenv AWS_RDS_URL=postgresql://pgmaster:postgres@database-url.rds.amazon.com:5432/doxa_db_staging
-else:
-  print('USING VARIABLE LOCAL')
-  application.config['SQLALCHEMY_DATABASE_URI'] = 'postgresql://localhost/doxa-db-dev'
-
-jobstore = SQLAlchemyJobStore(url=application.config['SQLALCHEMY_DATABASE_URI'])
-application.config['SCHEDULER_JOBSTORES'] = {
-  'default': jobstore
-}
-
-db = SQLAlchemy(application)
-bcrypt = Bcrypt(application)
-login_manager = LoginManager(application)
-login_manager.login_view = 'login'
-login_manager.login_message_category = 'info'
-
-scheduler = BackgroundScheduler()
-scheduler.add_jobstore(application.config.get('SCHEDULER_JOBSTORES').get('default'))
-scheduler.start()
-
-from application.scheduled_data_tasks import job_scheduler
-job_scheduler.schedule_jobs(scheduler)
-
-from application import routes
-from application import db
+# this makes certain things importable via from application.folder_name import thing_in_folder
 
 '''
 dev setup commands:
@@ -52,13 +9,12 @@ start PostgreSQL -> brew services start postgresql
 Then:
 createdb doxa-db-dev
 pip install -r requirements.txt
-python manage.py db init
 python manage.py db migrate (if you have new database changes)
 Then inspect the new migration! Does it look okay?
 python manage.py db upgrade (upgrades your database with new models)
 
 you can query / inspect your database using:
-psql doxa-db-dev
+psql -d doxa-db-dev
 
 if the migration does not work, you can run 
 python manage.py db downgrade

--- a/application/app_setup.py
+++ b/application/app_setup.py
@@ -1,0 +1,11 @@
+from application.initialize.config import Config
+from flask import Flask
+
+'''
+aws eb requires 'application' name for Flask instance
+This file needs to be in the `application` folder because
+the `__name__` variable is referenced by jinja2 for templating
+'''
+
+application = Flask(__name__)
+application.config['SECRET_KEY'] = Config.APPLICATION_SECRET_KEY

--- a/application/initialize/bcrypt_init.py
+++ b/application/initialize/bcrypt_init.py
@@ -1,0 +1,4 @@
+from flask_bcrypt import Bcrypt
+from application.app_setup import application
+
+bcrypt = Bcrypt(application)

--- a/application/initialize/config.py
+++ b/application/initialize/config.py
@@ -1,0 +1,26 @@
+import os
+
+class Config:
+  # basic stuff
+  APPLICATION_SECRET_KEY = '7a273729d601733097ead8f655a410eb'
+
+  # Slack API keys
+  SLACK_CLIENT_ID = os.environ.get('SLACK_CLIENT_ID') # stored in EB config
+  SLACK_CLIENT_SECRET = os.environ.get('SLACK_CLIENT_SECRET') # stored in EB config
+  
+  # database stuff
+  LOCAL_PG_URL = 'postgresql://localhost/doxa-db-dev'
+  postgres_url = os.environ.get('AWS_RDS_URL')
+  if postgres_url != None:
+    print('USING VARIABLE %s' % postgres_url)
+    SQLALCHEMY_DATABASE_URI = postgres_url
+  else:
+    print('USING VARIABLE LOCAL')
+    SQLALCHEMY_DATABASE_URI = LOCAL_PG_URL
+
+  # gets rid of annoying message when starting app
+  sqlalchemy_tracking_notifications = not os.environ.get('IS_PRODUCTION')
+  if sqlalchemy_tracking_notifications:
+    SQLALCHEMY_TRACK_MODIFICATIONS = True
+  else:
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/application/initialize/db_init.py
+++ b/application/initialize/db_init.py
@@ -1,0 +1,7 @@
+from flask_sqlalchemy import SQLAlchemy
+from application.app_setup import application
+from application.initialize.config import Config
+
+application.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = Config.SQLALCHEMY_TRACK_MODIFICATIONS
+application.config['SQLALCHEMY_DATABASE_URI'] = Config.SQLALCHEMY_DATABASE_URI
+db = SQLAlchemy(application)

--- a/application/initialize/login_manager_init.py
+++ b/application/initialize/login_manager_init.py
@@ -1,0 +1,6 @@
+from flask_login import LoginManager
+from application.app_setup import application
+
+login_manager = LoginManager(application)
+login_manager.login_view = 'login'
+login_manager.login_message_category = 'info'

--- a/application/initialize/scheduler_jobstore_init.py
+++ b/application/initialize/scheduler_jobstore_init.py
@@ -1,0 +1,15 @@
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from application.initialize.config import Config
+from application.app_setup import application
+
+jobstore = SQLAlchemyJobStore(url=Config.SQLALCHEMY_DATABASE_URI)
+application.config['SCHEDULER_JOBSTORES'] = {
+  'default': jobstore
+}
+application.config['SQLALCHEMY_DATABASE_URI'] = Config.SQLALCHEMY_DATABASE_URI
+
+scheduler = BackgroundScheduler()
+scheduler.add_jobstore(application.config.get('SCHEDULER_JOBSTORES').get('default'))
+print('starting scheduler...')
+scheduler.start()

--- a/application/models.py
+++ b/application/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from application import db, login_manager
+from application.initialize.login_manager_init import login_manager
+from application.initialize.db_init import db
 from flask_login import UserMixin
 from datetime import datetime
 

--- a/application/routes.py
+++ b/application/routes.py
@@ -2,13 +2,16 @@ import os
 import secrets
 from PIL import Image
 from flask import render_template, url_for, flash, redirect, request, abort
-from application import application, db, bcrypt
+from application.initialize.bcrypt_init import bcrypt
+from application.initialize.db_init import db
+from application.initialize.scheduler_jobstore_init import scheduler as apscheduler
+from application.app_setup import application
 from application.forms import RegistrationForm, LoginForm, UpdateAccountForm, PostForm
 from application.models import User, Post, RawSlackEvent
 from flask_login import login_user, current_user, logout_user, login_required
 from application import slack_auth
 from application.scheduled_data_tasks import apscheduler_util
-from application import scheduler as apscheduler
+
 
 @application.route('/slack-event', methods=['POST'])
 def slack_event():

--- a/application/run_server.py
+++ b/application/run_server.py
@@ -1,0 +1,9 @@
+from application.app_setup import application
+from application.initialize.db_init import db
+from application.initialize.login_manager_init import login_manager
+from application.initialize.bcrypt_init import bcrypt
+from application.initialize.scheduler_jobstore_init import scheduler
+from application.scheduled_data_tasks import job_scheduler
+from application import routes
+
+job_scheduler.schedule_jobs(scheduler)

--- a/application/scheduled_data_tasks/slack_activities.py
+++ b/application/scheduled_data_tasks/slack_activities.py
@@ -1,5 +1,5 @@
 from application.models import SlackUser, RawSlackEvent, SlackUserEvent
-from application import db
+from application.initialize.db_init import db
 from datetime import datetime
 
 def capture_slack_activites_from_stored_raw_json():

--- a/application/slack_auth.py
+++ b/application/slack_auth.py
@@ -1,5 +1,6 @@
 from flask import redirect, request
-from application import application
+from application.initialize.config import Config
+from application.app_setup import application
 from application.models import SlackTeam, SlackUser
 import slack
 import functools
@@ -8,8 +9,8 @@ from datetime import datetime
 SLACK_INSTALL_ROUTE = '/slack-install'
 SLACK_AUTH_ROUTE = '/slack-auth-one'
 
-SLACK_CLIENT_ID = application.config['SLACK_CLIENT_ID']
-SLACK_CLIENT_SECRET = application.config['SLACK_CLIENT_SECRET']
+SLACK_CLIENT_ID = Config.SLACK_CLIENT_ID
+SLACK_CLIENT_SECRET = Config.SLACK_CLIENT_SECRET
 
 SLACK_SCOPES = [
   'channels:history',
@@ -94,7 +95,6 @@ def slack_auth_route():
 def slack_install_route():
   slack_url = _build_slack_access_request()
   return redirect(slack_url)
-
 
 def _build_slack_access_request():
   scope = '%s' % functools.reduce(lambda one, two: one + ',' + two, SLACK_SCOPES)

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,5 @@
-from application import application, db
+from application.app_setup import application
+from application.initialize.db_init import db
 
 from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand


### PR DESCRIPTION
This is a refactor to make the app startup code (used to be in `application/__init__.py`) be run when anything from `application` gets imported. 

Now, if you need global config variables, you can put them in `application/initialize/config.py`, and access them by importing them: 
```
from application.initialize.config import Config
config_variable = Config.VARIABLE_NAME
```

As well, things to import are more split up. Now, to connect to the database, you just run `from application.initialize.db_init import db`. 

These changes are small, but should do a lot to help us avoid hitting annoying circular dependency issues, which are a pain to deal with.

@kushthaker @Callum-Mitchell 