### PR TITLE
Fixing Google Auth token

### DIFF
--- a/application/google_auth.py
+++ b/application/google_auth.py
@@ -61,10 +61,10 @@ def add_new_user_creds(credentials, primaryCal):
 @login_required
 def request_google_calendar_api():
 	if 'credentials' not in flask.session:
+		print('credentials not in flask session')
 		return flask.redirect(GOOGLE_CALENDAR_AUTH_ROUTE)
 
 	credentials = google.oauth2.credentials.Credentials(**flask.session['credentials'])
-
 	if credentials.expired is False and credentials.valid is True:
 		service = googleapiclient.discovery.build(API_SERVICE_NAME, API_VERSION, credentials=credentials)
 		try:
@@ -77,10 +77,9 @@ def request_google_calendar_api():
 	else:
 		flask.flash('Google account is not authorized.', 'danger')
 		return flask.redirect(flask.url_for('home'))
-
-	existing_user = GoogleCalendarUser.query.filter(GoogleCalendarUser.id == current_user.google_calendar_user.id).one_or_none()
-
-	if existing_user:
+	
+	if current_user.google_calendar_user:
+		existing_user = GoogleCalendarUser.query.filter(GoogleCalendarUser.id == current_user.google_calendar_user.id).one_or_none()
 		user = update_existing_user_creds(existing_user, credentials, primaryCal)
 	else:
 		user = add_new_user_creds(credentials, primaryCal)
@@ -124,11 +123,14 @@ def revoke_google_auth():
 	revoke = requests.post('https://accounts.google.com/o/oauth2/revoke', 
 		params={'token': credentials.token}, 
 		headers = {'content-type': 'application/x-www-form-urlencoded'})
-
 	status_code = getattr(revoke, 'status_code')
 
 	if status_code == 200:
-		return('Credentials successfully revoked.')
+		user = GoogleCalendarUser.query.filter(current_user.google_calendar_user.id == GoogleCalendarUser.id).one_or_none()
+		if user:
+			db.session.delete(user)
+			db.session.commit()
+		return('Credentials successfully revoked. Deleted current GoogleCalendarUser and child GoogleCalendarEvents.')
 	else:
 		return('Error with revoke post request to https://accounts.google.com/o/oauth2/revoke.')
 

--- a/application/scheduled_data_tasks/job_scheduler.py
+++ b/application/scheduled_data_tasks/job_scheduler.py
@@ -19,11 +19,15 @@ JOB_SCHEDULE = [
   },
   {
     'func': google_calendar_activities.update_google_calendar_events,
-    'trigger': apscheduler_util.build_hour_trigger(12)
+    'trigger': apscheduler_util.build_hour_trigger(1)
   },
   {
     'func': google_calendar_activities.delete_google_calendar_events,
-    'trigger': apscheduler_util.build_hour_trigger(12)
+    'trigger': apscheduler_util.build_hour_trigger(1)
+  },
+  {
+    'func': google_calendar_activities.refresh_google_credentials,
+    'trigger': apscheduler_util.build_minute_trigger(30)
   }
 ]
 


### PR DESCRIPTION
### What this does.

This is a formalization / merge to master of the #38 Google Calendar refresh issues / authentication issues:

> Fix bug where the existing user check fails when user does not exist. 

> Add refresh_google_auth job to refresh google auth without hitting throttle limits

It does not implement the cascading delete work, nor the time calculation work. It has been tested in staging. I will test this branch itself in staging before merging. 