### PR TITLE
header diff

### DIFF
--- a/application/doxa-frontend/src/components/Header.vue
+++ b/application/doxa-frontend/src/components/Header.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <b-navbar toggleable="lg" type="dark" variant="info">
+    <b-navbar toggleable="lg" type="dark" class="lookyherekushthaker">
       <div>
         <b-navbar-brand to="/">
           <img src="../assets/logo_transparent.png" alt="Fulfilled.ai" width="120" height="120">
@@ -44,6 +44,8 @@
   }
 </script>
 
-<!-- Add "scoped" attribute to limit CSS to this component only -->
-<style scoped>  
+<style>
+  .lookyherekushthaker {
+    background-color: #000000;
+  }
 </style>


### PR DESCRIPTION
@kushthaker here is an example header CSS change: changes background color from light blue to black

The issue was that it had a bootstrap `variant="info"` on it.