### PR TITLE
Fix google calendar job

### DIFF
--- a/application/scheduled_data_tasks/google_calendar_activities.py
+++ b/application/scheduled_data_tasks/google_calendar_activities.py
@@ -140,11 +140,10 @@ def delete_google_calendar_events():
 				print("Error with google_calendar_activities.delete_google_calendar_events.")
 				print(e)
 				continue
-
+	db.session.commit()
 	print("Deleted ", deleted_events, \
 		" GoogleCalendarEvents for ", len(users), \
-		" users.")			
-	
+		" users.")
 	return
 
 def refresh_google_credentials():

--- a/application/scheduled_data_tasks/job_scheduler.py
+++ b/application/scheduled_data_tasks/job_scheduler.py
@@ -6,16 +6,16 @@ JOB_SCHEDULE = [
     'trigger': apscheduler_util.build_hour_trigger(1)
   },
   {
+    'func': slack_activities.capture_slack_conversation_reads,
+    'trigger': apscheduler_util.build_minute_trigger(30)
+  },
+  {
     'func': slack_activities.capture_slack_conversations,
-    'trigger': apscheduler_util.build_hour_trigger(1)
+    'trigger': apscheduler_util.build_minute_trigger(5)
   },
   {
     'func': slack_activities.capture_slack_conversation_queries,
     'trigger': apscheduler_util.build_minute_trigger(5)
-  },
-  {
-    'func': slack_activities.capture_slack_conversation_reads,
-    'trigger': apscheduler_util.build_minute_trigger(30)
   },
   {
     'func': google_calendar_activities.update_google_calendar_events,


### PR DESCRIPTION
### What this does
I was browsing some logs from staging and noticed that there was an issue with Google Calendar event deletions - `db.session.commit()` was not being called. This means `DELETE` statements were being pushed into the db session but not getting committed. I _believe_ this was causing issues with other jobs, and may be related to #45, due to 

@kushthaker 